### PR TITLE
Add shoeprint dataset and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,28 @@ will only happen if neither a folder
 if you want to force running the dataset preparation again.
 
 
+### Shoeprint dataset
+Organize paired images as:
+```
+data/shoeprint/
+├── footprint/
+│   ├── 0001.jpg
+│   └── ...
+└── sole/
+    ├── 0001.jpg
+    └── ...
+```
+Each file in `footprint/` must have a corresponding mask in `sole/` with the same filename.
+
+To train the model run
+```bash
+python main.py --base models/ldm/shoeprint_ldm/config.yaml -t --gpus <n>
+```
+To sample from a checkpoint use
+```bash
+python scripts/sole2footprint.py --config models/ldm/shoeprint_ldm/config.yaml --ckpt <path> --indir <sole_dir>
+```
+
 ## Model Training
 
 Logs and checkpoints for trained models are saved to `logs/<START_DATE_AND_TIME>_<config_spec>`.

--- a/ldm/data/shoeprint.py
+++ b/ldm/data/shoeprint.py
@@ -1,0 +1,71 @@
+import os
+import random
+import numpy as np
+from PIL import Image
+from torch.utils.data import Dataset
+
+
+class ShoeprintBase(Dataset):
+    def __init__(self, data_root, size=None, interpolation="bicubic", flip_p=0.5):
+        self.data_root = data_root
+        self.sole_root = os.path.join(data_root, "sole")
+        self.image_root = os.path.join(data_root, "footprint")
+        self.paths = sorted([p for p in os.listdir(self.image_root)
+                             if os.path.isfile(os.path.join(self.image_root, p))])
+        self._length = len(self.paths)
+        self.size = size
+        self.interpolation = {"linear": Image.LINEAR,
+                              "bilinear": Image.BILINEAR,
+                              "bicubic": Image.BICUBIC,
+                              "lanczos": Image.LANCZOS}[interpolation]
+        self.flip_p = flip_p
+
+    def __len__(self):
+        return self._length
+
+    def _load_image(self, path):
+        return Image.open(path)
+
+    def __getitem__(self, i):
+        fname = self.paths[i]
+        img = self._load_image(os.path.join(self.image_root, fname)).convert("RGB")
+        sole = self._load_image(os.path.join(self.sole_root, fname)).convert("L")
+
+        img = np.array(img).astype(np.uint8)
+        sole = np.array(sole).astype(np.uint8)
+
+        crop = min(img.shape[0], img.shape[1])
+        h, w = img.shape[0], img.shape[1]
+        img = img[(h - crop) // 2:(h + crop) // 2,
+                  (w - crop) // 2:(w + crop) // 2]
+        sole = sole[(h - crop) // 2:(h + crop) // 2,
+                    (w - crop) // 2:(w + crop) // 2]
+
+        img = Image.fromarray(img)
+        sole = Image.fromarray(sole)
+        if self.size is not None:
+            img = img.resize((self.size, self.size), resample=self.interpolation)
+            sole = sole.resize((self.size, self.size), resample=self.interpolation)
+
+        if random.random() < self.flip_p:
+            img = img.transpose(Image.FLIP_LEFT_RIGHT)
+            sole = sole.transpose(Image.FLIP_LEFT_RIGHT)
+
+        img = np.array(img).astype(np.uint8)
+        sole = np.array(sole).astype(np.uint8)
+
+        example = {
+            "image": (img / 127.5 - 1.0).astype(np.float32),
+            "sole": (sole / 127.5 - 1.0).astype(np.float32),
+        }
+        return example
+
+
+class ShoeprintTrain(ShoeprintBase):
+    def __init__(self, data_root="data/shoeprint", size=None, flip_p=0.5, **kwargs):
+        super().__init__(data_root=data_root, size=size, flip_p=flip_p, **kwargs)
+
+
+class ShoeprintValidation(ShoeprintBase):
+    def __init__(self, data_root="data/shoeprint", size=None, flip_p=0.0, **kwargs):
+        super().__init__(data_root=data_root, size=size, flip_p=flip_p, **kwargs)

--- a/models/ldm/shoeprint_ldm/config.yaml
+++ b/models/ldm/shoeprint_ldm/config.yaml
@@ -1,0 +1,76 @@
+model:
+  base_learning_rate: 1.0e-06
+  target: ldm.models.diffusion.ddpm.LatentDiffusion
+  params:
+    linear_start: 0.0015
+    linear_end: 0.0155
+    log_every_t: 100
+    timesteps: 1000
+    loss_type: l1
+    first_stage_key: image
+    cond_stage_key: sole
+    conditioning_key: concat
+    image_size: 64
+    channels: 3
+    concat_mode: true
+    cond_stage_trainable: false
+    unet_config:
+      target: ldm.modules.diffusionmodules.openaimodel.UNetModel
+      params:
+        image_size: 64
+        in_channels: 4
+        out_channels: 3
+        model_channels: 160
+        attention_resolutions:
+        - 16
+        - 8
+        num_res_blocks: 2
+        channel_mult:
+        - 1
+        - 2
+        - 2
+        - 4
+        num_head_channels: 32
+    first_stage_config:
+      target: ldm.models.autoencoder.VQModelInterface
+      params:
+        embed_dim: 3
+        n_embed: 8192
+        monitor: val/rec_loss
+        ddconfig:
+          double_z: false
+          z_channels: 3
+          resolution: 256
+          in_channels: 3
+          out_ch: 3
+          ch: 128
+          ch_mult:
+          - 1
+          - 2
+          - 4
+          num_res_blocks: 2
+          attn_resolutions: []
+          dropout: 0.0
+        lossconfig:
+          target: torch.nn.Identity
+    cond_stage_config:
+      target: torch.nn.Identity
+
+data:
+  target: main.DataModuleFromConfig
+  params:
+    batch_size: 64
+    wrap: false
+    num_workers: 12
+    train:
+      target: ldm.data.shoeprint.ShoeprintTrain
+      params:
+        data_root: data/shoeprint
+        size: 256
+        flip_p: 0.5
+    validation:
+      target: ldm.data.shoeprint.ShoeprintValidation
+      params:
+        data_root: data/shoeprint
+        size: 256
+        flip_p: 0.0

--- a/scripts/sole2footprint.py
+++ b/scripts/sole2footprint.py
@@ -1,0 +1,58 @@
+import os
+import glob
+import argparse
+import numpy as np
+from PIL import Image
+import torch
+from omegaconf import OmegaConf
+
+from ldm.util import instantiate_from_config
+from ldm.models.diffusion.ddim import DDIMSampler
+
+
+def load_model(config, ckpt):
+    print(f"Loading model from {ckpt}")
+    pl_sd = torch.load(ckpt, map_location="cpu")
+    model = instantiate_from_config(config.model)
+    model.load_state_dict(pl_sd["state_dict"], strict=False)
+    model.cuda()
+    model.eval()
+    return model
+
+
+def prepare_mask(path, device):
+    m = Image.open(path).convert("L")
+    m = np.array(m).astype(np.float32) / 255.0
+    m = torch.from_numpy(m)[None, None]
+    m = m.to(device) * 2.0 - 1.0
+    return m
+
+
+def main(opt):
+    config = OmegaConf.load(opt.config)
+    model = load_model(config, opt.ckpt)
+    sampler = DDIMSampler(model)
+    os.makedirs(opt.outdir, exist_ok=True)
+    files = sorted(glob.glob(os.path.join(opt.indir, "*")))
+    for path in files:
+        cond = prepare_mask(path, model.device)
+        h, w = cond.shape[-2:]
+        shape = (model.first_stage_model.embed_dim, h // 8, w // 8)
+        samples, _ = sampler.sample(S=opt.steps, conditioning=cond,
+                                    batch_size=1, shape=shape, eta=opt.ddim_eta, verbose=False)
+        x = model.decode_first_stage(samples)
+        x = torch.clamp((x + 1.0) / 2.0, 0.0, 1.0)
+        x = 255. * x.cpu().permute(0, 2, 3, 1).numpy()[0]
+        Image.fromarray(x.astype(np.uint8)).save(os.path.join(opt.outdir, os.path.basename(path)))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, default="models/ldm/shoeprint_ldm/config.yaml")
+    parser.add_argument("--ckpt", type=str, required=True)
+    parser.add_argument("--indir", type=str, required=True, help="directory with sole masks")
+    parser.add_argument("--outdir", type=str, default="outputs/sole2footprint")
+    parser.add_argument("--steps", type=int, default=50)
+    parser.add_argument("--ddim_eta", type=float, default=0.0)
+    opt = parser.parse_args()
+    main(opt)


### PR DESCRIPTION
## Summary
- add `ShoeprintBase` dataset for paired sole/footprint images
- provide latent diffusion config for shoeprint generation
- document dataset organization and commands in README
- add simple inference script `sole2footprint.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5a9b2c708328a09de3cec36a0577